### PR TITLE
Add WeMos D1 R2 (mini) board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,6 +23,12 @@
 [version]
 build_flags = !echo "-DPIO_SRC_REV="$(git rev-parse HEAD) "-DPIO_BUILD_DATE="$(date +%%Y-%%m-%%d) "-DPIO_BUILD_TIME="$(date +%%H:%%M:%%S)
 
+[env:d1_mini]
+platform = espressif8266
+framework = arduino
+board = d1_mini
+build_flags = ${version.build_flags}
+
 [env:esp12e]
 platform = espressif8266
 framework = arduino


### PR DESCRIPTION
Adds the WeMos D1 R2 (mini) board to the build process. Platformio
documentation:

https://docs.platformio.org/en/latest/boards/espressif8266/d1_mini.html