### PR TITLE
edit get_parameters HTML page to view parameter values properly (not in raw)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,8 @@ void setup() {
     DEBUG_LOG("Local IP: %s\n", localIP.toString().c_str());
 
     Parameters.setLocalIPAddress(localIP);
+    Parameters.setLocalIPAddressInString(localIP.toString());
+    
     IPAddress gcs_ip(localIP);
     //-- I'm getting bogus IP from the DHCP server. Broadcasting for now.
     gcs_ip[3] = 255;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,8 +197,7 @@ void setup() {
     DEBUG_LOG("Local IP: %s\n", localIP.toString().c_str());
 
     Parameters.setLocalIPAddress(localIP);
-    Parameters.setLocalIPAddressInString(localIP.toString());
-    
+
     IPAddress gcs_ip(localIP);
     //-- I'm getting bogus IP from the DHCP server. Broadcasting for now.
     gcs_ip[3] = 255;

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -189,10 +189,10 @@ void handle_getParameters()
     message += "<p>Parameters</p><table><tr><td width=\"240\">Name</td><td>Value</td></tr>";
     for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
 		
-		if(i == ID_FWVER)
+		if(i == getWorld()->getParameters()->ID_FWVER)
 		{
 			message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
             message += MAVESP8266_VERSION_MAJOR;
@@ -202,10 +202,10 @@ void handle_getParameters()
             message += MAVESP8266_VERSION_BUILD;
             message += "</td></tr>";
 		}
-        else if(i == ID_MODE)
+        else if(i == getWorld()->getParameters()->ID_MODE)
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
             if(getWorld()->getParameters()->getWifiMode() == WIFI_MODE_AP)
@@ -218,67 +218,67 @@ void handle_getParameters()
             }
             message += "</td></tr>";
         }
-        else if(i == ID_IPADDRESS)
+        else if(i == getWorld()->getParameters()->ID_IPADDRESS)
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
             message += getWorld()->getParameters()->getLocalIPAddressInString();
             message += "</td></tr>";
         }
-        else if(i == ID_SSID1)
+        else if(i == getWorld()->getParameters()->ID_SSID1)
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
-            message += getWorld()->getParameters()->(const char*)getWifiSsid();
+            message += getWorld()->getParameters()->getWifiSsid();
             message += "</td></tr>";
         }
-        else if(i > ID_SSID1 && i <= ID_SSID4) {}
-        else if(i == ID_PASS1)
+        else if(i > getWorld()->getParameters()->ID_SSID1 && i <= getWorld()->getParameters()->ID_SSID4) {}
+        else if(i == getWorld()->getParameters()->ID_PASS1)
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
-            message += getWorld()->getParameters()->(const char*)getWifiPassword();
+            message += getWorld()->getParameters()->getWifiPassword();
             message += "</td></tr>";
         }
-        else if(i > ID_PASS1 && i <= ID_PASS4) {}
-        else if(i == ID_SSIDSTA1)
+        else if(i > getWorld()->getParameters()->ID_PASS1 && i <= getWorld()->getParameters()->ID_PASS4) {}
+        else if(i == getWorld()->getParameters()->ID_SSIDSTA1)
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
-            message += getWorld()->getParameters()->(const char*)getWifiStaSsid();
+            message += getWorld()->getParameters()->getWifiStaSsid();
             message += "</td></tr>";
         }
-        else if(i > ID_SSIDSTA1 && i <= ID_SSIDSTA4) {}
-        else if(i == ID_PASSSTA1)
+        else if(i > getWorld()->getParameters()->ID_SSIDSTA1 && i <= getWorld()->getParameters()->ID_SSIDSTA4) {}
+        else if(i == getWorld()->getParameters()->ID_PASSSTA1)
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             message += "<td>";
-            message += getWorld()->getParameters()->(const char*)getWifiStaPassword();
+            message += getWorld()->getParameters()->getWifiStaPassword();
             message += "</td></tr>";
         }
-        else if(i > ID_PASSSTA1 && i <= ID_PASSSTA4) {}
+        else if(i > getWorld()->getParameters()->ID_PASSSTA1 && i <= getWorld()->getParameters()->ID_PASSSTA4) {}
         else // integer values
         {
             message += "<tr><td>";
-            message += Param_getAt(i)->id;
+            message += getWorld()->getParameters()->getAt(i)->id;
             message += "</td>";
             unsigned long val = 0;
-            if (Param_getAt(i)->type == PARAM_TYPE_UINT32)
-                val = (unsigned long)*((UINT32 *)Param_getAt(i)->value);
-            else if (Param_getAt(i)->type == PARAM_TYPE_UINT16)
-                val = (unsigned long)*((UINT16 *)Param_getAt(i)->value);
+            if(getWorld()->getParameters()->getAt(i)->type == MAV_PARAM_TYPE_UINT32)
+                val = (unsigned long)*((uint32_t*)getWorld()->getParameters()->getAt(i)->value);
+            else if(getWorld()->getParameters()->getAt(i)->type == MAV_PARAM_TYPE_UINT16)
+                val = (unsigned long)*((uint16_t*)getWorld()->getParameters()->getAt(i)->value);
             else
-                val = (unsigned long)*((UINT8 *)Param_getAt(i)->value);
+                val = (unsigned long)*((int8_t*)getWorld()->getParameters()->getAt(i)->value);
 
             message += "<td>";
             message += val;

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -188,19 +188,102 @@ void handle_getParameters()
     String message = FPSTR(kHEADER);
     message += "<p>Parameters</p><table><tr><td width=\"240\">Name</td><td>Value</td></tr>";
     for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
-        message += "<tr><td>";
-        message += getWorld()->getParameters()->getAt(i)->id;
-        message += "</td>";
-        unsigned long val = 0;
-        if(getWorld()->getParameters()->getAt(i)->type == MAV_PARAM_TYPE_UINT32)
-            val = (unsigned long)*((uint32_t*)getWorld()->getParameters()->getAt(i)->value);
-        else if(getWorld()->getParameters()->getAt(i)->type == MAV_PARAM_TYPE_UINT16)
-            val = (unsigned long)*((uint16_t*)getWorld()->getParameters()->getAt(i)->value);
-        else
-            val = (unsigned long)*((int8_t*)getWorld()->getParameters()->getAt(i)->value);
-        message += "<td>";
-        message += val;
-        message += "</td></tr>";
+		
+		if(i == ID_FWVER)
+		{
+			message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            message += MAVESP8266_VERSION_MAJOR;
+            message += ".";
+            message += MAVESP8266_VERSION_MINOR;
+            message += ".";
+            message += MAVESP8266_VERSION_BUILD;
+            message += "</td></tr>";
+		}
+        else if(i == ID_MODE)
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            if(getWorld()->getParameters()->getWifiMode() == WIFI_MODE_AP)
+            {
+                message += "AP";
+            }
+            else
+            {
+                message += "STA";
+            }
+            message += "</td></tr>";
+        }
+        else if(i == ID_IPADDRESS)
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            message += getWorld()->getParameters()->getLocalIPAddressInString();
+            message += "</td></tr>";
+        }
+        else if(i == ID_SSID1)
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            message += getWorld()->getParameters()->(const char*)getWifiSsid();
+            message += "</td></tr>";
+        }
+        else if(i > ID_SSID1 && i <= ID_SSID4) {}
+        else if(i == ID_PASS1)
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            message += getWorld()->getParameters()->(const char*)getWifiPassword();
+            message += "</td></tr>";
+        }
+        else if(i > ID_PASS1 && i <= ID_PASS4) {}
+        else if(i == ID_SSIDSTA1)
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            message += getWorld()->getParameters()->(const char*)getWifiStaSsid();
+            message += "</td></tr>";
+        }
+        else if(i > ID_SSIDSTA1 && i <= ID_SSIDSTA4) {}
+        else if(i == ID_PASSSTA1)
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            message += "<td>";
+            message += getWorld()->getParameters()->(const char*)getWifiStaPassword();
+            message += "</td></tr>";
+        }
+        else if(i > ID_PASSSTA1 && i <= ID_PASSSTA4) {}
+        else // integer values
+        {
+            message += "<tr><td>";
+            message += Param_getAt(i)->id;
+            message += "</td>";
+            unsigned long val = 0;
+            if (Param_getAt(i)->type == PARAM_TYPE_UINT32)
+                val = (unsigned long)*((UINT32 *)Param_getAt(i)->value);
+            else if (Param_getAt(i)->type == PARAM_TYPE_UINT16)
+                val = (unsigned long)*((UINT16 *)Param_getAt(i)->value);
+            else
+                val = (unsigned long)*((UINT8 *)Param_getAt(i)->value);
+
+            message += "<td>";
+            message += val;
+            message += "</td></tr>";
+        }
     }
     message += "</table>";
     message += "</body>";

--- a/src/mavesp8266_parameters.cpp
+++ b/src/mavesp8266_parameters.cpp
@@ -123,7 +123,7 @@ MavESP8266Parameters::begin()
 void
 MavESP8266Parameters::setLocalIPAddress(IPAddress ipAddress)
 {
-    _wifi_ip_address = ipAddress;
+    _wifi_ip_address = (uint32_t)ipAddress;
     _wifi_ip_addr_string = ipAddress.toString();
 }
 

--- a/src/mavesp8266_parameters.cpp
+++ b/src/mavesp8266_parameters.cpp
@@ -65,6 +65,8 @@ uint32_t    _wifi_subnetsta;
 uint32_t    _uart_baud_rate;
 uint32_t    _flash_left;
 
+String      _wifi_ip_addr_string;
+
 //-- Parameters
 //   No string support in parameters so we stash a char[16] into 4 uint32_t
  struct stMavEspParameters mavParameters[] = {
@@ -119,9 +121,18 @@ MavESP8266Parameters::begin()
 //---------------------------------------------------------------------------------
 //-- Initialize
 void
-MavESP8266Parameters::setLocalIPAddress(uint32_t ipAddress)
+MavESP8266Parameters::setLocalIPAddress(IPAddress ipAddress)
 {
     _wifi_ip_address = ipAddress;
+    _wifi_ip_addr_string = ipAddress.toString();
+}
+
+//---------------------------------------------------------------------------------
+//-- Initialize
+String
+MavESP8266Parameters::getLocalIPAddressInString()
+{
+    return(_wifi_ip_addr_string);
 }
 
 //---------------------------------------------------------------------------------

--- a/src/mavesp8266_parameters.h
+++ b/src/mavesp8266_parameters.h
@@ -126,7 +126,9 @@ public:
     void        setWifiStaGateway           (uint32_t addr);
     void        setWifiStaSubnet            (uint32_t addr);
     void        setUartBaudRate             (uint32_t baud);
-    void        setLocalIPAddress           (uint32_t ipAddress);
+    void        setLocalIPAddress           (IPAddress ipAddress);
+
+    String      getLocalIPAddressInString   ();
 
     stMavEspParameters* getAt               (int index);
 


### PR DESCRIPTION
I have changed "handle_getParameters()" function to get the value of some parameters from a valid address not from "void *". This helps users to show parameters values much better in HTML page. Also I have tested in hardware and the result was as this picture:
![image](https://user-images.githubusercontent.com/34955147/96537675-ba547b00-12a3-11eb-8ed1-ce3ad96e1a0e.png)
