### PR TITLE
add multicast support

### DIFF
--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -64,8 +64,8 @@ class MavESP8266GCS;
 
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
-#define MAVESP8266_VERSION_MINOR    2
-#define MAVESP8266_VERSION_BUILD    3
+#define MAVESP8266_VERSION_MINOR    3
+#define MAVESP8266_VERSION_BUILD    0
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -66,6 +66,9 @@ const char* kDEBUG      = "debug";
 const char* kREBOOT     = "reboot";
 const char* kPOSITION   = "position";
 const char* kMODE       = "mode";
+const char* kCASTMODE   = "castmode";
+const char* kMCASTIP    = "mcastip";
+const char* kMCASTPORT  = "mcastport";
 
 const char* kFlashMaps[7] = {
     "512KB (256/256)",
@@ -316,14 +319,37 @@ static void handle_setup()
     message += IP.toString();
     message += "'><br>";
 
-    message += "Host Port:&nbsp;";
+    message += "Casting Mode:&nbsp;";
+    message += "<input type='radio' name='castmode' value='0'";
+    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_UNI) {
+        message += " checked";
+    }
+    message += ">Unicast\n";
+    message += "<input type='radio' name='castmode' value='1'";
+    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_MULTI) {
+        message += " checked";
+    }
+    message += ">Multicast<br>\n";
+
+    message += "Unicast Host Port:&nbsp;";
     message += "<input type='text' name='hport' value='";
     message += getWorld()->getParameters()->getWifiUdpHport();
     message += "'><br>";
 
-    message += "Client Port:&nbsp;";
+    message += "Unicast Client Port:&nbsp;";
     message += "<input type='text' name='cport' value='";
     message += getWorld()->getParameters()->getWifiUdpCport();
+    message += "'><br>";
+
+    message += "Multicast IP:&nbsp;";
+    message += "<input type='text' name='mcastip' value='";
+    IP = getWorld()->getParameters()->getWifiMcastIP();
+    message += IP.toString();
+    message += "'><br>";
+
+    message += "Multicast Port:&nbsp;";
+    message += "<input type='text' name='mcastport' value='";
+    message += getWorld()->getParameters()->getWifiMcastPort();
     message += "'><br>";
     
     message += "Baudrate:&nbsp;";
@@ -536,6 +562,19 @@ void handle_setParameters()
     if(webServer.hasArg(kREBOOT)) {
         ok = true;
         reboot = webServer.arg(kREBOOT) == "1";
+    }
+    if(webServer.hasArg(kCASTMODE)) {
+        ok = true;
+        getWorld()->getParameters()->setWifiCastMode(webServer.arg(kCASTMODE).toInt());
+    }
+    if(webServer.hasArg(kMCASTIP)) {
+        IPAddress ip;
+        ip.fromString(webServer.arg(kMCASTIP).c_str());
+        getWorld()->getParameters()->setWifiMcastIP(ip);
+    }
+    if(webServer.hasArg(kMCASTPORT)) {
+        ok = true;
+        getWorld()->getParameters()->setWifiMcastPort(webServer.arg(kMCASTPORT).toInt());
     }
     if(ok) {
         getWorld()->getParameters()->saveAllToEeprom();

--- a/src/mavesp8266_parameters.cpp
+++ b/src/mavesp8266_parameters.cpp
@@ -65,6 +65,9 @@ uint32_t    _wifi_subnetsta;
 uint32_t    _uart_baud_rate;
 uint32_t    _flash_left;
 int8_t      _raw_enable;
+int8_t      _wifi_cast_mode;
+uint32_t    _wifi_mcast_ip;
+uint16_t    _wifi_mcast_port;
 
 //-- Parameters
 //   No string support in parameters so we stash a char[16] into 4 uint32_t
@@ -97,6 +100,9 @@ int8_t      _raw_enable;
      {"WIFI_SUBNET_STA",    &_wifi_subnetsta,       MavESP8266Parameters::ID_SUBNETSTA, sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
      {"UART_BAUDRATE",      &_uart_baud_rate,       MavESP8266Parameters::ID_UART,      sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
      {"RAW_ENABLE",         &_raw_enable,           MavESP8266Parameters::ID_RAW_ENABLE,sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
+     {"WIFI_CAST_MODE",     &_wifi_cast_mode,       MavESP8266Parameters::ID_CAST_MODE, sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
+     {"WIFI_MCAST_IP",      &_wifi_mcast_ip,        MavESP8266Parameters::ID_MCAST_IP,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_MCAST_PORT",    &_wifi_mcast_port,      MavESP8266Parameters::ID_MCAST_PORT,sizeof(uint16_t),   MAV_PARAM_TYPE_UINT16,  false},
 };
 
 //---------------------------------------------------------------------------------
@@ -154,6 +160,9 @@ uint32_t    MavESP8266Parameters::getWifiStaGateway () { return _wifi_gatewaysta
 uint32_t    MavESP8266Parameters::getWifiStaSubnet  () { return _wifi_subnetsta;    }
 uint32_t    MavESP8266Parameters::getUartBaudRate   () { return _uart_baud_rate;    }
 int8_t      MavESP8266Parameters::getRawEnable      () { return _raw_enable;        }
+int8_t      MavESP8266Parameters::getWifiCastMode   () { return _wifi_cast_mode;    }
+uint32_t    MavESP8266Parameters::getWifiMcastIP    () { return _wifi_mcast_ip;     }
+uint16_t    MavESP8266Parameters::getWifiMcastPort  () { return _wifi_mcast_port;   }
 
 //---------------------------------------------------------------------------------
 //-- Reset all to defaults
@@ -170,6 +179,9 @@ MavESP8266Parameters::resetToDefaults()
     _wifi_ipsta        = 0;
     _wifi_gatewaysta   = 0;
     _wifi_subnetsta    = 0;
+    _wifi_cast_mode    = 0;
+    _wifi_mcast_ip     = DEFAULT_MCAST_IP;
+    _wifi_mcast_port   = DEFAULT_UDP_HPORT;
     strncpy(_wifi_ssid,         kDEFAULT_SSID,      sizeof(_wifi_ssid));
     strncpy(_wifi_password,     kDEFAULT_PASSWORD,  sizeof(_wifi_password));
     strncpy(_wifi_ssidsta,      kDEFAULT_SSID,      sizeof(_wifi_ssidsta));
@@ -411,4 +423,25 @@ void
 MavESP8266Parameters::setUartBaudRate(uint32_t baud)
 {
     _uart_baud_rate = baud;
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiCastMode(int8_t enabled)
+{
+    _wifi_cast_mode = enabled;
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiMcastIP(uint32_t ip)
+{
+    _wifi_mcast_ip = ip;
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiMcastPort(uint16_t port)
+{
+    _wifi_mcast_port = port;
 }

--- a/src/mavesp8266_parameters.h
+++ b/src/mavesp8266_parameters.h
@@ -41,12 +41,16 @@
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_STA 1
 
+#define CAST_MODE_UNI 0
+#define CAST_MODE_MULTI 1
+
 //-- Constants
 #define DEFAULT_WIFI_MODE       WIFI_MODE_AP
 #define DEFAULT_UART_SPEED      921600
 #define DEFAULT_WIFI_CHANNEL    11
 #define DEFAULT_UDP_HPORT       14550
 #define DEFAULT_UDP_CPORT       14555
+#define DEFAULT_MCAST_IP        848429039
 
 struct stMavEspParameters {
     char        id[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN];
@@ -90,7 +94,10 @@ public:
         ID_SUBNETSTA,
         ID_UART,
         ID_RAW_ENABLE,
-        ID_COUNT
+        ID_CAST_MODE,
+        ID_MCAST_IP,
+        ID_MCAST_PORT,
+        ID_COUNT,
     };
 
     void        begin                       ();
@@ -114,6 +121,9 @@ public:
     uint32_t    getWifiStaSubnet            ();
     uint32_t    getUartBaudRate             ();
     int8_t      getRawEnable                ();
+    int8_t      getWifiCastMode             ();
+    uint32_t    getWifiMcastIP              ();
+    uint16_t    getWifiMcastPort            ();
 
     void        setDebugEnabled             (int8_t enabled);
     void        setWifiMode                 (int8_t mode);
@@ -129,6 +139,9 @@ public:
     void        setWifiStaSubnet            (uint32_t addr);
     void        setUartBaudRate             (uint32_t baud);
     void        setLocalIPAddress           (uint32_t ipAddress);
+    void        setWifiCastMode             (int8_t mode);
+    void        setWifiMcastIP              (uint32_t ip);
+    void        setWifiMcastPort            (uint16_t port);
 
     stMavEspParameters* getAt               (int index);
 


### PR DESCRIPTION
This adds multicast support to the mavesp8266 firmware. The user can select between unicast and multicast mode using the web interface and specify the multicast ip and the port. The multicast functionality works only when the esp module is connected to an access point using the STA interface. When doing multicast, the esp modules can communicate with each other on the specified multicast ip and port. 
The default multicast ip and port are `239.255.145.50` and `14550` respectively.
The user can connect mavproxy to all the vehicles in multicast mode using the command `mavproxy.py --master mcast: --console --map` (if the multicast ip and port are set to default and the gcs is also connected to the same access point).
![image](https://github.com/ArduPilot/mavesp8266/assets/67995771/7cde78cb-c892-40fe-8e89-0fa3af4ca3a1)

