### PR TITLE
Add conservative multicast mode for location sharing

### DIFF
--- a/src/mavesp8266.cpp
+++ b/src/mavesp8266.cpp
@@ -201,3 +201,24 @@ void MavESP8266Bridge::handle_non_mavlink(uint8_t b, bool msgReceived)
     }
     _last_parse_state = _rxstatus.parse_state;
 }
+
+/*
+    helper to check if a message is restricted to pass through the bridge
+*/
+bool MavESP8266Bridge::restricted_message(mavlink_message_t* message)
+{
+    if (getWorld()->getParameters()->getWifiCastMode() != CAST_MODE_CONS_MULTI) {
+        // restrict messages only in conservative multicast mode
+        return false;
+    }
+
+    // allowed messages
+    switch(message->msgid) {
+    case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:
+    case MAVLINK_MSG_ID_FOLLOW_TARGET:
+        return false;
+    }
+
+    // restrict all other messages
+    return true;
+}

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -121,6 +121,7 @@ protected:
     mavlink_status_t        _rxstatus;
 
     void handle_non_mavlink(uint8_t b, bool msgReceived);
+    bool restricted_message(mavlink_message_t* message);
     uint8_t _non_mavlink_buffer[270];
     uint16_t _non_mavlink_len;
     mavlink_parse_state_t _last_parse_state;

--- a/src/mavesp8266_gcs.cpp
+++ b/src/mavesp8266_gcs.cpp
@@ -64,7 +64,7 @@ MavESP8266GCS::begin(MavESP8266Bridge* forwardTo, IPAddress gcsIP)
         _udp_port = getWorld()->getParameters()->getWifiUdpHport();
         _udp.begin(getWorld()->getParameters()->getWifiUdpCport());
         break;
-    case CAST_MODE_MULTI:
+    case CAST_MODE_FULL_MULTI ... CAST_MODE_CONS_MULTI:
         _ip = getWorld()->getParameters()->getWifiMcastIP();
         _udp_port = getWorld()->getParameters()->getWifiMcastPort();
         _udp.beginMulticast(WiFi.localIP(), _ip, _udp_port);
@@ -80,7 +80,9 @@ MavESP8266GCS::readMessage()
     //-- Read UDP
     if(_readMessage()) {
         //-- If we have a message, forward it
-        _forwardTo->sendMessage(&_message);
+        if(!restricted_message(&_message)) {
+            _forwardTo->sendMessage(&_message);
+        }
         memset(&_message, 0, sizeof(_message));
     }
     uint32_t now = millis();
@@ -240,7 +242,7 @@ MavESP8266GCS::sendMessageRaw(uint8_t *buffer, int len)
         _udp.beginPacket(_ip, _udp_port);
         break;
         
-    case CAST_MODE_MULTI:
+    case CAST_MODE_FULL_MULTI ... CAST_MODE_CONS_MULTI:
         _udp.beginPacketMulticast(_ip, _udp_port, WiFi.localIP());
         break;
     }

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -66,6 +66,9 @@ const char* kDEBUG      = "debug";
 const char* kREBOOT     = "reboot";
 const char* kPOSITION   = "position";
 const char* kMODE       = "mode";
+const char* kCASTMODE   = "castmode";
+const char* kMCASTIP    = "mcastip";
+const char* kMCASTPORT  = "mcastport";
 
 const char* kFlashMaps[7] = {
     "512KB (256/256)",
@@ -325,6 +328,29 @@ static void handle_setup()
     message += "<input type='text' name='cport' value='";
     message += getWorld()->getParameters()->getWifiUdpCport();
     message += "'><br>";
+
+    message += "Casting Mode:&nbsp;";
+    message += "<input type='radio' name='castmode' value='0'";
+    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_UNI) {
+        message += " checked";
+    }
+    message += ">Unicast\n";
+    message += "<input type='radio' name='castmode' value='1'";
+    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_MULTI) {
+        message += " checked";
+    }
+    message += ">Multicast<br>\n";
+
+    message += "Multicast IP:&nbsp;";
+    message += "<input type='text' name='mcastip' value='";
+    IP = getWorld()->getParameters()->getWifiMcastIP();
+    message += IP.toString();
+    message += "'><br>";
+
+    message += "Multicast Port:&nbsp;";
+    message += "<input type='text' name='mcastport' value='";
+    message += getWorld()->getParameters()->getWifiMcastPort();
+    message += "'><br>";
     
     message += "Baudrate:&nbsp;";
     message += "<input type='text' name='baud' value='";
@@ -536,6 +562,19 @@ void handle_setParameters()
     if(webServer.hasArg(kREBOOT)) {
         ok = true;
         reboot = webServer.arg(kREBOOT) == "1";
+    }
+    if(webServer.hasArg(kCASTMODE)) {
+        ok = true;
+        getWorld()->getParameters()->setWifiCastMode(webServer.arg(kCASTMODE).toInt());
+    }
+    if(webServer.hasArg(kMCASTIP)) {
+        IPAddress ip;
+        ip.fromString(webServer.arg(kMCASTIP).c_str());
+        getWorld()->getParameters()->setWifiMcastIP(ip);
+    }
+    if(webServer.hasArg(kMCASTPORT)) {
+        ok = true;
+        getWorld()->getParameters()->setWifiMcastPort(webServer.arg(kMCASTPORT).toInt());
     }
     if(ok) {
         getWorld()->getParameters()->saveAllToEeprom();

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -336,10 +336,15 @@ static void handle_setup()
     }
     message += ">Unicast\n";
     message += "<input type='radio' name='castmode' value='1'";
-    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_MULTI) {
+    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_FULL_MULTI) {
         message += " checked";
     }
-    message += ">Multicast<br>\n";
+    message += ">Full Multicast\n";
+    message += "<input type='radio' name='castmode' value='2'";
+    if (getWorld()->getParameters()->getWifiCastMode() == CAST_MODE_CONS_MULTI) {
+        message += " checked";
+    }
+    message += ">Conservative Multicast<br>\n";
 
     message += "Multicast IP:&nbsp;";
     message += "<input type='text' name='mcastip' value='";

--- a/src/mavesp8266_parameters.cpp
+++ b/src/mavesp8266_parameters.cpp
@@ -65,6 +65,9 @@ uint32_t    _wifi_subnetsta;
 uint32_t    _uart_baud_rate;
 uint32_t    _flash_left;
 int8_t      _raw_enable;
+int8_t      _wifi_cast_mode;
+uint32_t    _wifi_mcast_ip;
+uint16_t    _wifi_mcast_port;
 
 //-- Parameters
 //   No string support in parameters so we stash a char[16] into 4 uint32_t
@@ -97,6 +100,9 @@ int8_t      _raw_enable;
      {"WIFI_SUBNET_STA",    &_wifi_subnetsta,       MavESP8266Parameters::ID_SUBNETSTA, sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
      {"UART_BAUDRATE",      &_uart_baud_rate,       MavESP8266Parameters::ID_UART,      sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
      {"RAW_ENABLE",         &_raw_enable,           MavESP8266Parameters::ID_RAW_ENABLE,sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
+     {"WIFI_CAST_MODE",     &_wifi_cast_mode,       MavESP8266Parameters::ID_CAST_MODE, sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
+     {"WIFI_MCAST_IP",      &_wifi_mcast_ip,        MavESP8266Parameters::ID_MCAST_IP,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_MCAST_PORT",    &_wifi_mcast_port,      MavESP8266Parameters::ID_MCAST_PORT,sizeof(uint16_t),   MAV_PARAM_TYPE_UINT16,  false},
 };
 
 //---------------------------------------------------------------------------------
@@ -154,6 +160,9 @@ uint32_t    MavESP8266Parameters::getWifiStaGateway () { return _wifi_gatewaysta
 uint32_t    MavESP8266Parameters::getWifiStaSubnet  () { return _wifi_subnetsta;    }
 uint32_t    MavESP8266Parameters::getUartBaudRate   () { return _uart_baud_rate;    }
 int8_t      MavESP8266Parameters::getRawEnable      () { return _raw_enable;        }
+int8_t      MavESP8266Parameters::getWifiCastMode   () { return _wifi_cast_mode;    }
+uint32_t    MavESP8266Parameters::getWifiMcastIP    () { return _wifi_mcast_ip;     }
+uint16_t    MavESP8266Parameters::getWifiMcastPort  () { return _wifi_mcast_port;   }
 
 //---------------------------------------------------------------------------------
 //-- Reset all to defaults
@@ -170,6 +179,9 @@ MavESP8266Parameters::resetToDefaults()
     _wifi_ipsta        = 0;
     _wifi_gatewaysta   = 0;
     _wifi_subnetsta    = 0;
+    _wifi_cast_mode    = 0;
+    _wifi_mcast_ip     = DEFAULT_MCAST_IP;
+    _wifi_mcast_port   = DEFAULT_UDP_HPORT;
     strncpy(_wifi_ssid,         kDEFAULT_SSID,      sizeof(_wifi_ssid));
     strncpy(_wifi_password,     kDEFAULT_PASSWORD,  sizeof(_wifi_password));
     strncpy(_wifi_ssidsta,      kDEFAULT_SSID,      sizeof(_wifi_ssidsta));
@@ -411,4 +423,25 @@ void
 MavESP8266Parameters::setUartBaudRate(uint32_t baud)
 {
     _uart_baud_rate = baud;
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiCastMode(int8_t enabled)
+{
+    _wifi_cast_mode = enabled;
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiMcastIP(uint32_t ip)
+{
+    _wifi_mcast_ip = ip;
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiMcastPort(uint16_t port)
+{
+    _wifi_mcast_port = port;
 }

--- a/src/mavesp8266_parameters.h
+++ b/src/mavesp8266_parameters.h
@@ -42,7 +42,8 @@
 #define WIFI_MODE_STA 1
 
 #define CAST_MODE_UNI 0
-#define CAST_MODE_MULTI 1
+#define CAST_MODE_FULL_MULTI 1
+#define CAST_MODE_CONS_MULTI 2
 
 //-- Constants
 #define DEFAULT_WIFI_MODE       WIFI_MODE_AP

--- a/src/mavesp8266_parameters.h
+++ b/src/mavesp8266_parameters.h
@@ -41,12 +41,16 @@
 #define WIFI_MODE_AP 0
 #define WIFI_MODE_STA 1
 
+#define CAST_MODE_UNI 0
+#define CAST_MODE_MULTI 1
+
 //-- Constants
 #define DEFAULT_WIFI_MODE       WIFI_MODE_AP
 #define DEFAULT_UART_SPEED      921600
 #define DEFAULT_WIFI_CHANNEL    11
 #define DEFAULT_UDP_HPORT       14550
 #define DEFAULT_UDP_CPORT       14555
+#define DEFAULT_MCAST_IP        848429039
 
 struct stMavEspParameters {
     char        id[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN];
@@ -90,7 +94,10 @@ public:
         ID_SUBNETSTA,
         ID_UART,
         ID_RAW_ENABLE,
-        ID_COUNT
+        ID_CAST_MODE,
+        ID_MCAST_IP,
+        ID_MCAST_PORT,
+        ID_COUNT,
     };
 
     void        begin                       ();
@@ -114,6 +121,9 @@ public:
     uint32_t    getWifiStaSubnet            ();
     uint32_t    getUartBaudRate             ();
     int8_t      getRawEnable                ();
+    int8_t      getWifiCastMode             ();
+    uint32_t    getWifiMcastIP              ();
+    uint16_t    getWifiMcastPort            ();
 
     void        setDebugEnabled             (int8_t enabled);
     void        setWifiMode                 (int8_t mode);
@@ -129,6 +139,9 @@ public:
     void        setWifiStaSubnet            (uint32_t addr);
     void        setUartBaudRate             (uint32_t baud);
     void        setLocalIPAddress           (uint32_t ipAddress);
+    void        setWifiCastMode             (int8_t mode);
+    void        setWifiMcastIP              (uint32_t ip);
+    void        setWifiMcastPort            (uint16_t port);
 
     stMavEspParameters* getAt               (int index);
 

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -72,7 +72,9 @@ void
 MavESP8266Vehicle::readMessage()
 {
     if (_readMessage()) {
-        _forwardTo->sendMessage(&_msg);
+        if(!restricted_message(&_msg)) {
+            _forwardTo->sendMessage(&_msg);
+        }
     }
     //-- Update radio status (1Hz)
     if(_heard_from && (millis() - _last_status_time > 1000)) {


### PR DESCRIPTION
This provides a _conservative_ multicast mode in esp firmware to allow users to share ONLY the position of vehicles among each other when they are connected to a common access point. The method of establishing communication among the vehicles is similar to the _full_ multicast mode. The esp modules need to be connected to a common access point and have same multicast ip and port. The vehicles would be able to share just the GLOBAL_POS_INT (and FOLLOW_TARGET) messages with each other this way. This would save huge amount of bandwidth. The reduction in traffic would allow more vehicles to be connected using multicast and ensure reliable connection for follow and avoidance purposes.
This should be merged after #11.